### PR TITLE
Update README: document single-value mode, ESPHome mode, and field/tag renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A Docker image is available. All configuration is done through environment varia
 # docker-compose.yml example:
 services:
   mqtt2influxdb:
-    image: mqtt2influxdb:latest
+    image: ghcr.io/cdzombak/mqtt2influxdb:latest
     environment:
       MQTT_SERVER: mqtt://my-broker:1883
       MQTT_TOPIC: sensors/temperature

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each `mqtt2influxdb` instance subscribes to a single MQTT topic (or, in ESPHome 
 
 ## Usage
 
-```
+```text
 mqtt2influxdb [options]
 ```
 
@@ -156,7 +156,7 @@ All configuration is done through environment variables. These can be set direct
 
 By default, `mqtt2influxdb` needs to determine whether each key in the message is an InfluxDB field or a tag. You can control this using environment variables of the form:
 
-```
+```text
 M2I_<CANONICALIZED_NAME>_ISA=<field|tag|drop>
 ```
 
@@ -176,7 +176,7 @@ If a key's field/tag status cannot be determined (no ISA hint and no prefix like
 
 By default, values are written to InfluxDB with their JSON type. You can override this with environment variables of the form:
 
-```
+```text
 M2I_<CANONICALIZED_FIELD_NAME>_TYPE=<int|float|double|string|bool>
 ```
 
@@ -194,7 +194,7 @@ M2I_<CANONICALIZED_FIELD_NAME>_TYPE=<int|float|double|string|bool>
 
 You can rename any field or tag after canonicalization using environment variables of the form:
 
-```
+```text
 M2I_<CANONICALIZED_NAME>_RENAME=<new_name>
 ```
 
@@ -202,7 +202,7 @@ The new name is always lowercased. This applies in all modes (JSON, single-value
 
 For example, to rename a field `temp_f` to `temperature`:
 
-```
+```text
 M2I_TEMP_F_RENAME=temperature
 ```
 
@@ -216,7 +216,7 @@ M2I_TEMP_F_RENAME=temperature
 | `HEARTBEAT_GET_URL` | URL to send periodic GET requests to as a heartbeat. |
 | `HEARTBEAT_INTERVAL_S` | Interval between heartbeat requests, in seconds. |
 | `HEARTBEAT_THRESHOLD_S` | Maximum time since last successful MQTT message before the health check reports unhealthy, in seconds. |
-| `HEALTH_PORT` | Port to serve a health check HTTP endpoint on. |
+| `HEARTBEAT_HEALTH_PORT` | Port to serve a health check HTTP endpoint on. |
 
 ### Timestamp Parsing
 
@@ -229,7 +229,7 @@ In the future, multiple timestamp formats may be supported; see [#3](https://git
 
 ### Deduplication
 
-In JSON mode, you can enable deduplication to skip messages that have already been processed. Set `DEDUPE_ON` to the name of a JSON key whose value should be used for deduplication. If two consecutive messages have the same value for this key, the second message is skipped.
+In JSON mode, you can enable deduplication to skip messages that have already been processed. Set `DEDUPE_ON` to the name of a JSON key whose value should be used for deduplication. Any message whose value for this key has already been seen during the application's lifetime will be skipped.
 
 > [!NOTE]
 > `DEDUPE_ON` is only supported in JSON mode.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 An opinionated and intentionally scope-limited MQTT to InfluxDB bridge.
 
-> [!NOTE]  
-> This README is incomplete (tracked in [#1](https://github.com/cdzombak/mqtt2influxdb/issues/1)).
-
 ## Goals & Features
 
 - Get simple JSON data from MQTT to InfluxDB
@@ -16,34 +13,77 @@ An opinionated and intentionally scope-limited MQTT to InfluxDB bridge.
 
 ### Multiple topics/subscriptions
 
-tk
-orchestration, retries, etc
+Each `mqtt2influxdb` instance subscribes to a single MQTT topic (or, in ESPHome mode, a set of topics derived from a single prefix). To bridge multiple topics, run multiple instances of `mqtt2influxdb` and use your orchestration tool (systemd, Docker Compose, etc.) to manage them.
 
 ### Infinitely flexible schema/transformations
 
-tk
-can't necessarily work with every message format
-can't necessarily work with weird key names or most nested structures
-doesn't support non-JSON
+`mqtt2influxdb` can't necessarily work with every message format. It does not support non-JSON payloads in JSON mode, and it may not handle unusual key names or deeply nested structures gracefully. For more complex transformation needs, consider a more full-featured ETL tool.
 
 ## Usage
 
-tk
+```
+mqtt2influxdb [options]
+```
 
 ### Arguments
 
-tk
-
-- `-env-files`
-- `-strict`
-- `-help`
-- `-version`
-
-note, strict overrides `FIELDTAG_DETERMINATION_FAILURE` and `CAST_FAILURE`
+- `-env-files`: Comma-separated list of `.env` files to load. Earlier files take precedence over later ones. No `.env` file values will overwrite currently-set environment variables. See [godotenv's precedence documentation](https://github.com/joho/godotenv?tab=readme-ov-file#precedence--conventions) for details.
+- `-strict`: Exit on invalid messages, unexpected topics, casting failures, or other unexpected conditions. This overrides `FIELDTAG_DETERMINATION_FAILURE` and `CAST_FAILURE` policies, setting both to `fatal`.
+- `-version`: Print version and exit.
+- `-help`: Print usage information and exit.
 
 ### Docker
 
-tk
+A Docker image is available. All configuration is done through environment variables (and optionally `.env` files via `-env-files`). The image is built from scratch with only the binary and CA certificates included.
+
+```yaml
+# docker-compose.yml example:
+services:
+  mqtt2influxdb:
+    image: mqtt2influxdb:latest
+    environment:
+      MQTT_SERVER: mqtt://my-broker:1883
+      MQTT_TOPIC: sensors/temperature
+      INFLUX_SERVER: http://influxdb:8086
+      INFLUX_BUCKET: my-db/autogen
+      INFLUX_MEASUREMENT_NAME: temperature
+      M2I_MODE: json
+```
+
+### Message Modes
+
+`mqtt2influxdb` supports three message modes, configured via the `M2I_MODE` environment variable. The default mode is `json`.
+
+#### JSON Mode (`M2I_MODE=json`)
+
+The default mode. Each MQTT message payload is expected to be a JSON object. Top-level keys are parsed into InfluxDB fields and tags according to the field/tag mapping and type hint rules described below.
+
+#### Single-Value Mode (`M2I_MODE=single`)
+
+In single-value mode, each MQTT message payload is treated as a single value (not parsed as JSON). This is useful for topics that publish a plain numeric or string value.
+
+**Required:** `M2I_SINGLE_FIELDNAME` must be set to specify the InfluxDB field name for the value.
+
+Type hints and renames work the same as in JSON mode, keyed on the canonical form of the field name given by `M2I_SINGLE_FIELDNAME`.
+
+> [!NOTE]
+> `DEDUPE_ON` is not supported in single-value mode.
+
+#### ESPHome Mode (`M2I_MODE=esphome`)
+
+ESPHome mode is designed to work with [ESPHome](https://esphome.io) devices publishing via MQTT. Instead of subscribing to a single topic, `mqtt2influxdb` subscribes to the following topic patterns derived from `MQTT_TOPIC` (used as the device's topic prefix):
+
+- `<MQTT_TOPIC>/status` — device online/offline status (parsed as bool)
+- `<MQTT_TOPIC>/binary_sensor/+/state` — binary sensor states (parsed as bool)
+- `<MQTT_TOPIC>/sensor/+/state` — sensor values (parsed using default rules/hints)
+- `<MQTT_TOPIC>/switch/+/state` — switch states (parsed as bool)
+
+The sensor/switch name from the topic path is used as the InfluxDB field name. Type hints and renames apply based on this field name.
+
+**Optional:** `M2I_ESPHOME_TRIM_SENSOR_PREFIX` can be set to trim a common prefix from sensor names. For example, if your ESPHome device publishes to `prefix/sensor/livingroom_temperature/state`, setting `M2I_ESPHOME_TRIM_SENSOR_PREFIX=livingroom_` would use `temperature` as the field name.
+
+> [!NOTE]
+> `DEDUPE_ON` is not supported in ESPHome mode.
 
 ### Timestamps
 
@@ -53,83 +93,134 @@ If the message contains a top-level entry named `at`, `ts`, or `time`, that valu
 
 #### rtl_433 compatibility
 
-tk: ` -M time:iso:utc:tz` 
+To produce compatible timestamps from [rtl_433](https://github.com/merbanan/rtl_433), use the flag `-M time:iso:utc:tz` to output ISO 8601/RFC 3339 timestamps in UTC.
 
 ### Key Names, Canonicalization, and Nesting
 
-tk
+Key names from JSON messages are canonicalized (lowercased) before being used as InfluxDB field or tag names. When referenced in environment variable names (for ISA mappings, type hints, and renames), key names are uppercased.
 
-per The Open Group Base Specifications https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html , any char other than NUL or `=` is allowed in an env var name.
+The following characters are replaced with `_` during canonicalization:
+- ASCII control characters (code 0-31)
+- `=`
+- `#`
 
-Influx disallows(ish) ( https://docs.influxdata.com/influxdb/v1/write_protocols/line_protocol_reference/#special-characters ): #, and the names time, _field, _measurement.
+The following names are disallowed as keys: `time`, `_measurement`, `_field`.
 
-For sanity I also disallow ASCII control chars (character code 0-31). And I recommend you don't use 
-periods (.) or mixed case as that could cause collisions.
+Nested JSON objects and arrays are supported. Nested keys are joined with `.` (e.g., a key `temp` inside an object `sensor` becomes `sensor.temp`). Array elements are indexed numerically (e.g., `values.0`, `values.1`).
 
-lowercased except in env vars, when they're all uppercased.
+> [!NOTE]
+> Avoid using periods (`.`) or mixed case in key names, as canonicalization could cause collisions.
+
+#### Special JSON keys
+
+In JSON mode, certain top-level keys receive special handling:
+
+- `t` or `tags`: All entries within this object are treated as tags.
+- `f` or `fields`: All entries within this object are treated as fields.
+- Keys prefixed with `t_`: The remainder of the key (after `t_`) is treated as a tag name.
+- Keys prefixed with `f_`: The remainder of the key (after `f_`) is treated as a field name.
+- `at`, `ts`, or `time`: Parsed as the point's timestamp (see [Timestamps](#timestamps)).
 
 ## Configuration
 
-tk
+All configuration is done through environment variables. These can be set directly or loaded from `.env` files via the `-env-files` argument.
 
 ### MQTT
 
-tk
-
-- `MQTT_SERVER`
-- `MQTT_TOPIC`
-- `MQTT_USER`
-- `MQTT_PASS`
-- `MQTT_QOS`
-- `MQTT_CLIENT_ID`
-- `MQTT_CLEAN_START`
-- `MQTT_KEEP_ALIVE_S`
-- `MQTT_SESSION_EXPIRY_S`
+| Variable | Description | Required | Default |
+|---|---|---|---|
+| `MQTT_SERVER` | MQTT broker URL. The `mqtt://` scheme prefix is added automatically if not present. | **Yes** | — |
+| `MQTT_TOPIC` | MQTT topic to subscribe to (or topic prefix in ESPHome mode). | **Yes** | — |
+| `MQTT_USER` | MQTT username for authentication. | No | — |
+| `MQTT_PASS` | MQTT password for authentication. Also accepted as `MQTT_PASSWORD`. | No | — |
+| `MQTT_QOS` | MQTT QoS level (0, 1, or 2). | No | `0` |
+| `MQTT_CLIENT_ID` | MQTT client ID. If unset, a random ID is generated based on hostname. | No | Auto-generated |
+| `MQTT_CLEAN_START` | Whether to start with a clean MQTT session (`true`/`false`). | No | `false` |
+| `MQTT_KEEP_ALIVE_S` | MQTT keep-alive interval in seconds. | No | `20` |
+| `MQTT_SESSION_EXPIRY_S` | MQTT session expiry interval in seconds. | No | `0` |
 
 ### Influx
 
-tk
-
-- `INFLUX_SERVER`
-- `INFLUX_USER`
-- `INFLUX_PASS`
-- `INFLUX_BUCKET`
-- `INFLUX_MEASUREMENT_NAME`
-- `INFLUX_TIMEOUT_S`
-- `INFLUX_RETRIES`
-- `INFLUX_TAGS`
+| Variable | Description | Required | Default |
+|---|---|---|---|
+| `INFLUX_SERVER` | InfluxDB server URL. `http://` is added automatically if no scheme is present. | **Yes** | — |
+| `INFLUX_USER` | InfluxDB username. | No | — |
+| `INFLUX_PASS` | InfluxDB password. Also accepted as `INFLUX_PASSWORD`. | No | — |
+| `INFLUX_BUCKET` | InfluxDB bucket (in InfluxDB 1.x, use `database/retention_policy` format). | **Yes** | — |
+| `INFLUX_MEASUREMENT_NAME` | InfluxDB measurement name for all written points. | **Yes** | — |
+| `INFLUX_TIMEOUT_S` | Timeout for InfluxDB write operations, in seconds. | No | `5` |
+| `INFLUX_RETRIES` | Number of retry attempts for failed InfluxDB writes. | No | `2` |
+| `INFLUX_TAGS` | Comma-separated `key=value` pairs of tags to add to every point (e.g. `host=server1,env=prod`). | No | — |
 
 ### Field/Tag Mapping
 
-tk
+By default, `mqtt2influxdb` needs to determine whether each key in the message is an InfluxDB field or a tag. You can control this using environment variables of the form:
 
-Typically, we auto TK
+```
+M2I_<CANONICALIZED_NAME>_ISA=<field|tag|drop>
+```
 
-Format: `M2I_<canonicalized-name>_ISA=<field|tag|drop>`
+- `field`: Treat this key as an InfluxDB field.
+- `tag`: Treat this key as an InfluxDB tag (value is always stored as a string).
+- `drop`: Ignore this key entirely.
 
-- `FIELDTAG_DETERMINATION_FAILURE`: `ignore`, `log`, or `fatal`
+The canonicalized name is the uppercased, canonicalized version of the key. For nested keys, use `.` as the separator (e.g. `M2I_SENSOR.TEMP_ISA=field`).
+
+If a key's field/tag status cannot be determined (no ISA hint and no prefix like `t_` or `f_`), the behavior is controlled by:
+
+| Variable | Description | Default |
+|---|---|---|
+| `FIELDTAG_DETERMINATION_FAILURE` | Policy when a key's field/tag status is unknown. One of `ignore`, `log`, or `fatal`. | `log` |
 
 ### Data Type Hints
 
-tk
+By default, values are written to InfluxDB with their JSON type. You can override this with environment variables of the form:
 
-Format: `M2I_<canonicalized-field-name>_TYPE=<int|float|double|string|bool>`
+```
+M2I_<CANONICALIZED_FIELD_NAME>_TYPE=<int|float|double|string|bool>
+```
 
-- `CAST_FAILURE`: `ignore`, `log`, or `fatal`
-- `DEFAULT_NUMBERS_TO_FLOAT`: `true` or `false`
+- `int`: Parse or convert the value to an integer. Strings are parsed; floats are rounded; booleans become 0/1.
+- `float` or `double`: Parse or convert the value to a 64-bit float. Strings are parsed; booleans become 0.0/1.0.
+- `string`: Convert the value to its string representation.
+- `bool`: Parse the value as a boolean. Accepted string values: `1`, `t`, `true`, `on`, `online` (true) and `0`, `f`, `false`, `off`, `offline` (false). Non-negative integers and floats are also accepted (0 is false, nonzero is true).
+
+| Variable | Description | Default |
+|---|---|---|
+| `CAST_FAILURE` | Policy when a type cast fails. One of `ignore`, `log`, or `fatal`. | `log` |
+| `DEFAULT_NUMBERS_TO_FLOAT` | When `true`, untyped numeric values from JSON are written as floats instead of their default JSON number type. | `false` |
+
+### Renaming Fields and Tags
+
+You can rename any field or tag after canonicalization using environment variables of the form:
+
+```
+M2I_<CANONICALIZED_NAME>_RENAME=<new_name>
+```
+
+The new name is always lowercased. This applies in all modes (JSON, single-value, and ESPHome).
+
+For example, to rename a field `temp_f` to `temperature`:
+
+```
+M2I_TEMP_F_RENAME=temperature
+```
 
 ### Heartbeat
 
-tk
+> [!NOTE]
+> Heartbeat support is not yet implemented (tracked in [#2](https://github.com/cdzombak/mqtt2influxdb/issues/2)).
 
-- `HEARTBEAT_GET_URL`
-- `HEARTBEAT_INTERVAL_S`
-- `HEARTBEAT_THRESHOLD_S`
-- `HEALTH_PORT`
+| Variable | Description |
+|---|---|
+| `HEARTBEAT_GET_URL` | URL to send periodic GET requests to as a heartbeat. |
+| `HEARTBEAT_INTERVAL_S` | Interval between heartbeat requests, in seconds. |
+| `HEARTBEAT_THRESHOLD_S` | Maximum time since last successful MQTT message before the health check reports unhealthy, in seconds. |
+| `HEALTH_PORT` | Port to serve a health check HTTP endpoint on. |
 
 ### Timestamp Parsing
 
-If a message contains a timestamp field, it must be a string and will be parsed as an RFC3339 timestamp.
+If a message contains a timestamp field, it must be a string and will be parsed as an RFC 3339 timestamp.
 
 > [!NOTE]  
 > Timestamps from an Apple platform formatted as `NSISO8601DateFormatWithInternetDateTime` **will** be parsed correctly by this program.
@@ -138,13 +229,16 @@ In the future, multiple timestamp formats may be supported; see [#3](https://git
 
 ### Deduplication
 
-tk; for JSON mode only
+In JSON mode, you can enable deduplication to skip messages that have already been processed. Set `DEDUPE_ON` to the name of a JSON key whose value should be used for deduplication. If two consecutive messages have the same value for this key, the second message is skipped.
 
-- `DEDUPE_ON`
+> [!NOTE]
+> `DEDUPE_ON` is only supported in JSON mode.
 
 ### Multiple .env files
 
-tk
+You can load configuration from multiple `.env` files using the `-env-files` argument with a comma-separated list of file paths. Files are processed in order, with **earlier** files taking precedence over later ones. No `.env` file values will overwrite environment variables that are already set.
+
+See [godotenv's precedence documentation](https://github.com/joho/godotenv?tab=readme-ov-file#precedence--conventions) for details on precedence behavior.
 
 ## License
 


### PR DESCRIPTION
## Summary

Replaces all placeholder (`tk`) sections in the README with complete documentation, addressing issues #6, #7, and #8:

- **Single-value mode** (#6): Documents `M2I_MODE=single` and `M2I_SINGLE_FIELDNAME`
- **ESPHome mode** (#7): Documents `M2I_MODE=esphome`, topic subscription patterns, auto-bool typing for binary_sensor/switch, and `M2I_ESPHOME_TRIM_SENSOR_PREFIX`
- **Renaming** (#8): Documents `M2I_<NAME>_RENAME` env var format

Also fills in all other stub sections: arguments, Docker usage, MQTT/Influx config tables, key canonicalization rules, special JSON keys, type hint details, deduplication, and `.env` file precedence. Removes the "README is incomplete" banner.

No code changes — documentation only.

### Updates since initial revision

- Added `text` language identifier to all fenced code blocks (markdownlint MD040)
- Fixed `HEALTH_PORT` → `HEARTBEAT_HEALTH_PORT` in the Heartbeat config table to match the code
- Reworded deduplication description: now correctly states values are tracked persistently (not just consecutive)
- Changed Docker compose example image from `mqtt2influxdb:latest` to `ghcr.io/cdzombak/mqtt2influxdb:latest` to match the CI/publish workflow

## Review & Testing Checklist for Human

- [ ] **ESPHome mode documentation**: Verify the topic subscription patterns (`status`, `binary_sensor/+/state`, `sensor/+/state`, `switch/+/state`) and auto-bool typing behavior match the implementation in `handleESPHomeMsg`. This is the highest-risk section since ESPHome behavior is the most nuanced.
- [ ] **Env var defaults and descriptions**: Spot-check a few env var defaults (e.g. `MQTT_QOS=0`, `MQTT_KEEP_ALIVE_S=20`, `INFLUX_TIMEOUT_S=5`, `INFLUX_RETRIES=2`) against the source to confirm accuracy.
- [ ] **Special JSON keys**: Verify the documented behavior of `t`/`tags`, `f`/`fields`, `t_`/`f_` prefixes matches what the code actually does.
- [ ] **Removal of "README incomplete" note**: Confirm you're comfortable removing this given heartbeat is still unimplemented (it is noted separately as not-yet-implemented with a link to #2).

**Suggested test plan:** Skim each major README section against the corresponding source file (`main.go`, `parse.go`, `hints.go`, `keys.go`) to confirm env var names, defaults, and behavioral descriptions are accurate. No runtime testing needed since this is docs-only.

### Notes

- All documentation was derived from reading the source code (`main.go`, `parse.go`, `hints.go`, `keys.go`, `errpolicy.go`). The program was not run to verify behavior end-to-end, so there may be subtle inaccuracies in behavioral descriptions.

Link to Devin session: https://app.devin.ai/sessions/7120c921178b4e5cacd3431509f92c77
Requested by: @cdzombak