### PR TITLE
Implement heartbeat support (closes #2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ WORKDIR /src/${BIN_NAME}
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
 
-FROM scratch
+FROM alpine:latest
 ARG BIN_NAME
 ARG BIN_VERSION
+RUN apk add --no-cache curl
 COPY --from=builder /src/${BIN_NAME}/out/${BIN_NAME} /usr/bin/${BIN_NAME}
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/usr/bin/mqtt2influxdb"]
 
 LABEL license="LGPL3"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ services:
       INFLUX_BUCKET: my-db/autogen
       INFLUX_MEASUREMENT_NAME: temperature
       M2I_MODE: json
+      HEARTBEAT_INTERVAL_S: 30
+      HEARTBEAT_THRESHOLD_S: 120
+      HEARTBEAT_GET_URL: https://uptimekuma.example.com:9001/api/push/abcdabcd?status=up&msg=OK&ping=
+      # optionally, serve a health endpoint for external monitoring:
+      # HEARTBEAT_HEALTH_PORT: 8080
 ```
 
 ### Message Modes
@@ -208,15 +213,18 @@ M2I_TEMP_F_RENAME=temperature
 
 ### Heartbeat
 
-> [!NOTE]
-> Heartbeat support is not yet implemented (tracked in [#2](https://github.com/cdzombak/mqtt2influxdb/issues/2)).
+Heartbeat support allows health monitoring via an outgoing HTTP GET heartbeat and/or an HTTP health check server. The heartbeat is triggered each time an MQTT message is received. If no message has been received within the liveness threshold, the health endpoint reports unhealthy and outgoing heartbeats are paused.
+
+This is implemented using [`github.com/cdzombak/heartbeat`](https://github.com/cdzombak/heartbeat).
 
 | Variable | Description |
 |---|---|
-| `HEARTBEAT_GET_URL` | URL to send periodic GET requests to as a heartbeat. |
-| `HEARTBEAT_INTERVAL_S` | Interval between heartbeat requests, in seconds. |
-| `HEARTBEAT_THRESHOLD_S` | Maximum time since last successful MQTT message before the health check reports unhealthy, in seconds. |
-| `HEARTBEAT_HEALTH_PORT` | Port to serve a health check HTTP endpoint on. |
+| `HEARTBEAT_GET_URL` | URL to send periodic GET requests to as a heartbeat. Works well with [Uptime Kuma](https://github.com/louislam/uptime-kuma) push monitors. |
+| `HEARTBEAT_INTERVAL_S` | Interval between heartbeat GET requests, in seconds. Required if `HEARTBEAT_GET_URL` is set. |
+| `HEARTBEAT_THRESHOLD_S` | Maximum time since the last received MQTT message before the health check reports unhealthy and outgoing heartbeats are paused, in seconds. Required if any heartbeat feature is enabled. |
+| `HEARTBEAT_HEALTH_PORT` | Port to serve a health check HTTP endpoint on. A GET to `/` returns `{"ok":true}` with HTTP 200 when healthy, or `{"ok":false}` with HTTP 503 when unhealthy. |
+
+At least one of `HEARTBEAT_GET_URL` or `HEARTBEAT_HEALTH_PORT` must be set for heartbeat features to be enabled.
 
 ### Timestamp Parsing
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,15 @@ services:
       M2I_MODE: json
       HEARTBEAT_INTERVAL_S: 30
       HEARTBEAT_THRESHOLD_S: 120
-      HEARTBEAT_GET_URL: https://uptimekuma.example.com:9001/api/push/abcdabcd?status=up&msg=OK&ping=
-      # optionally, serve a health endpoint for external monitoring:
-      # HEARTBEAT_HEALTH_PORT: 8080
+      HEARTBEAT_HEALTH_PORT: 8080
+      # optionally, ping a remote monitor like Uptime Kuma:
+      # HEARTBEAT_GET_URL: https://uptimekuma.example.com:9001/api/push/abcdabcd?status=up&msg=OK&ping=
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 ```
 
 ### Message Modes

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/cdzombak/heartbeat v1.1.1 // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
+	github.com/cdzombak/heartbeat v1.1.1
 	github.com/eclipse/paho.golang v0.23.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/cdzombak/heartbeat v1.1.1 // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/cdzombak/heartbeat v1.1.1 h1:0GsQQdZn7JtwOPaheZwuOYmN3P+QOj44IyMAE8oEPjg=
+github.com/cdzombak/heartbeat v1.1.1/go.mod h1:pK5GKvyesTKeHFpI4PeJSElTO0m0TqjG/r9PG81yyGA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go"
+	"github.com/cdzombak/heartbeat"
 	"github.com/eclipse/paho.golang/autopaho"
 	"github.com/eclipse/paho.golang/paho"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -339,9 +340,22 @@ func Main(ctx context.Context, cfg Config) error {
 
 	influxWriter := newInfluxWriter(ctx, cfg.Influx)
 
-	// heartbeat tracked at: https://github.com/cdzombak/mqtt2influxdb/issues/2
+	var hb heartbeat.Heartbeat
 	if cfg.Heartbeat.GetURL != "" || cfg.Heartbeat.HealthPort != 0 {
-		log.Fatalf("heartbeat is not yet implemented")
+		var err error
+		hb, err = heartbeat.NewHeartbeat(&heartbeat.Config{
+			HeartbeatInterval: cfg.Heartbeat.Interval,
+			LivenessThreshold: cfg.Heartbeat.Threshold,
+			HeartbeatURL:      cfg.Heartbeat.GetURL,
+			Port:              int(cfg.Heartbeat.HealthPort),
+			OnError: func(err error) {
+				log.Printf("heartbeat error: %s", err)
+			},
+		})
+		if err != nil {
+			log.Fatalf("failed to create heartbeat: %s", err)
+		}
+		hb.Start()
 	}
 
 	receivedMessages := make(chan paho.PublishReceived)
@@ -353,6 +367,9 @@ func Main(ctx context.Context, cfg Config) error {
 			case <-ctx.Done():
 				return
 			case rm := <-receivedMessages:
+				if hb != nil {
+					hb.Alive(time.Now())
+				}
 				if cfg.Mode == MsgModeJSON {
 					var msg map[string]any
 					if err := json.Unmarshal(rm.Packet.Payload, &msg); err != nil {

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  HEARTBEAT_GET_URL")
 	fmt.Fprintln(os.Stderr, "  HEARTBEAT_INTERVAL_S")
 	fmt.Fprintln(os.Stderr, "  HEARTBEAT_THRESHOLD_S")
-	fmt.Fprintln(os.Stderr, "  HEALTH_PORT")
+	fmt.Fprintln(os.Stderr, "  HEARTBEAT_HEALTH_PORT")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "mqtt2influxdb is written by Chris Dzombak <https://www.dzombak.com> and licensed under the LGPL-3.0 license.")
 	fmt.Fprintln(os.Stderr, "🌐 https://www.github.com/cdzombak/mqtt2influxdb")
@@ -341,7 +341,7 @@ func Main(ctx context.Context, cfg Config) error {
 	influxWriter := newInfluxWriter(ctx, cfg.Influx)
 
 	var hb heartbeat.Heartbeat
-	if cfg.Heartbeat.GetURL != "" || cfg.Heartbeat.HealthPort != 0 {
+	if cfg.Heartbeat != nil && (cfg.Heartbeat.GetURL != "" || cfg.Heartbeat.HealthPort != 0) {
 		var err error
 		hb, err = heartbeat.NewHeartbeat(&heartbeat.Config{
 			HeartbeatInterval: cfg.Heartbeat.Interval,


### PR DESCRIPTION
## Summary

Integrates [`github.com/cdzombak/heartbeat`](https://github.com/cdzombak/heartbeat) to implement the heartbeat feature tracked in #2. This provides:

- **Outgoing HTTP GET heartbeat** via `HEARTBEAT_GET_URL` (e.g., for Uptime Kuma push monitors)
- **Health check HTTP server** via `HEARTBEAT_HEALTH_PORT` (returns 200/503 JSON response)
- **Liveness tracking** based on MQTT message receipt — `hb.Alive(time.Now())` is called each time a message is received from the broker

The `log.Fatalf("heartbeat is not yet implemented")` placeholder is replaced with actual initialization. README is updated with heartbeat documentation and the docker-compose example now includes heartbeat configuration with a Docker healthcheck.

### Updates since last revision

- **Dockerfile base image changed from `scratch` to `alpine:latest`** to make `curl` available inside the container for Docker healthchecks. The explicit CA certificates copy was removed (Alpine includes them natively).
- **Docker-compose example** now includes a `healthcheck` block using `curl -sf http://localhost:8080/` against the heartbeat health port.

## Review & Testing Checklist for Human

- [ ] **Dockerfile: `scratch` → `alpine:latest`** — This increases the image size and attack surface. Verify this tradeoff is acceptable. Also consider pinning to a specific Alpine version (e.g. `alpine:3.21`) instead of `latest` for reproducible builds.
- [ ] **CA certificates**: The `COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/` line was removed since Alpine provides its own. Verify TLS connections (to MQTT brokers, InfluxDB, heartbeat URLs) still work correctly in the new image.
- [ ] **`hb.Alive()` is called on every received message, _before_ parsing/processing.** This means even malformed or deduped messages mark the service as alive. Verify this is the desired behavior — the alternative would be to call `Alive()` only after successful InfluxDB writes.
- [ ] **`heartbeat` dependency is in the `indirect` require block in `go.mod`** — it should be in the direct block since `main.go` imports it directly. Run `go mod tidy` to verify.
- [ ] **Test end-to-end:** Deploy with `HEARTBEAT_HEALTH_PORT` set and verify `GET /` returns `{"ok":false}` (503) before any MQTT message, then `{"ok":true}` (200) after a message is received, then back to unhealthy after the threshold elapses with no messages. Also verify the Docker healthcheck reports healthy/unhealthy as expected.

### Notes
- No explicit config validation for `HEARTBEAT_INTERVAL_S` / `HEARTBEAT_THRESHOLD_S` when heartbeat is enabled. The library returns an error for zero/missing values, which is caught and fatal-logged, but the error message may be less user-friendly than a dedicated check.

Link to Devin session: https://app.devin.ai/sessions/bef24a8464b740abbc65be5cc28f034b
Requested by: @cdzombak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heartbeat now active: sends an HTTP GET on each received MQTT message, exposes a health endpoint that returns 503 and pauses outgoing heartbeats when liveness threshold is exceeded.

* **Documentation**
  * Docker Compose example and config docs updated with heartbeat env vars, healthcheck example, clarified semantics, conditional requirements, and enablement rules.

* **Chores**
  * Runtime image switched to Alpine with curl; added heartbeat module dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->